### PR TITLE
test: fix flaky test TestNonblockSelectRace

### DIFF
--- a/chann_test.go
+++ b/chann_test.go
@@ -245,7 +245,6 @@ func TestNonblockSelectRace(t *testing.T) {
 		c1 := chann.New[int]()
 		c2 := chann.New[int]()
 		c1.In() <- 1
-		time.Sleep(time.Millisecond)
 		go func() {
 			runtime.Gosched()
 			select {
@@ -279,7 +278,6 @@ func TestNonblockSelectRace2(t *testing.T) {
 		c1 := make(chan int, 1)
 		c2 := make(chan int)
 		c1 <- 1
-		time.Sleep(time.Millisecond)
 		go func() {
 			select {
 			case <-c1:

--- a/chann_test.go
+++ b/chann_test.go
@@ -230,7 +230,7 @@ func TestNonblockRecvRace(t *testing.T) {
 //	make c1 ready for receiving
 //	create second goroutine
 //	make c2 ready for receiving
-//	make c1 no longer ready for receiving (if possible)
+//	make c2 no longer ready for receiving (if possible)
 // The second goroutine does a non-blocking select receiving from c1 and c2.
 // From the time the second goroutine is created, at least one of c1 and c2
 // is always ready for receiving, so the select in the second goroutine must
@@ -245,6 +245,7 @@ func TestNonblockSelectRace(t *testing.T) {
 		c1 := chann.New[int]()
 		c2 := chann.New[int]()
 		c1.In() <- 1
+		time.Sleep(time.Millisecond)
 		go func() {
 			runtime.Gosched()
 			select {
@@ -258,7 +259,7 @@ func TestNonblockSelectRace(t *testing.T) {
 		}()
 		c2.In() <- 1
 		select {
-		case <-c1.Out():
+		case <-c2.Out():
 		default:
 		}
 		if !<-done.Out() {
@@ -278,6 +279,7 @@ func TestNonblockSelectRace2(t *testing.T) {
 		c1 := make(chan int, 1)
 		c2 := make(chan int)
 		c1 <- 1
+		time.Sleep(time.Millisecond)
 		go func() {
 			select {
 			case <-c1:
@@ -290,7 +292,7 @@ func TestNonblockSelectRace2(t *testing.T) {
 		}()
 		close(c2)
 		select {
-		case <-c1:
+		case <-c2:
 		default:
 		}
 		if !<-done {


### PR DESCRIPTION
close https://github.com/golang-design/chann/issues/1

This way we ensure that c1 always has a value and that c2 also serves the purpose of the test.