### PR TITLE
chann: support to consume all data after Close the channel.

### DIFF
--- a/chann.go
+++ b/chann.go
@@ -207,14 +207,12 @@ func (ch *Chann[T]) unboundedTerminate() {
 		ch.q = append(ch.q, e)
 	}
 	for len(ch.q) > 0 {
-		select {
 		// Note if receiver doesn't consume all data that has been sent to input
 		// channel, the `unboundedProcessing` goroutine will leak forever.
 		// Ref: https://github.com/golang-design/chann/issues/3
-		case ch.out <- ch.q[0]:
-			ch.q[0] = nilT // de-reference earlier to help GC
-			ch.q = ch.q[1:]
-		}
+		ch.out <- ch.q[0]
+		ch.q[0] = nilT // de-reference earlier to help GC
+		ch.q = ch.q[1:]
 	}
 	close(ch.out)
 	close(ch.close)

--- a/chann.go
+++ b/chann.go
@@ -79,7 +79,6 @@ func Cap(n int) Opt {
 // one, and use Cap to configure the capacity of the channel.
 type Chann[T any] struct {
 	in, out chan T
-	backlog chan T
 	close   chan struct{}
 	cfg     *config
 	q       []T
@@ -130,7 +129,6 @@ func New[T any](opts ...Opt) *Chann[T] {
 	case unbounded:
 		ch.in = make(chan T, 16)
 		ch.out = make(chan T, 16)
-		ch.backlog = make(chan T, 1024)
 		go ch.unboundedProcessing()
 	}
 	return ch


### PR DESCRIPTION
ref: #3 

In order to fix this new bug: https://github.com/golang-design/chann/issues/3#issuecomment-1150189421, this PR removes the default branch when sending backlog data into output channel.

The drawback is when there is no receiver or the receiver doesn't consume all data that has been sent to input channel, the `unboundedProcessing` goroutine will leak forever. IMO the user of this library should take care of this behavior. 

Considering the channel behavior in standard library, if user doesn't receive data from a buffered channel, data in the buffered channel is still kept in memory and has memory leak too, even if the channel is closed.